### PR TITLE
Added min to NestedScoreMode

### DIFF
--- a/src/Nest/QueryDsl/Joining/Nested/NestedScoreMode.cs
+++ b/src/Nest/QueryDsl/Joining/Nested/NestedScoreMode.cs
@@ -11,6 +11,8 @@ namespace Nest
 		Average,
 		[EnumMember(Value = "total")]
 		Total,
+		[EnumMember(Value = "min")]
+		Min,
 		[EnumMember(Value = "max")]
 		Max,
 		[EnumMember(Value = "none")]


### PR DESCRIPTION
This is supported by ES 2.x, but missing from NEST SDK. Already added in 5.x branch